### PR TITLE
use separate boot image arguments for ubuntu boot.img

### DIFF
--- a/mkbootimg.mk
+++ b/mkbootimg.mk
@@ -23,6 +23,11 @@ $(foreach MSM8226_DTS_NAME, $(MSM8226_DTS_NAMES), \
       cat $(KERNEL_ZIMG) $(call DTB_FILE,$(d)) > $(call ZIMG_FILE,$(d));))
 endef
 
+# use separate boot image arguments for ubuntu boot.img
+INTERNAL_BOOTIMAGE_ARGS_UBUNTU := \
+    --cmdline "$(BOARD_KERNEL_CMDLINE)" \
+    --base $(BOARD_KERNEL_BASE) \
+    --pagesize $(BOARD_KERNEL_PAGESIZE)
 
 ## Build and run dtbtool
 DTBTOOL := $(HOST_OUT_EXECUTABLES)/dtbToolCM$(HOST_EXECUTABLE_SUFFIX)
@@ -35,13 +40,19 @@ $(INSTALLED_DTIMAGE_TARGET): $(DTBTOOL) $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/u
 	$(hide) $(DTBTOOL) -o $(INSTALLED_DTIMAGE_TARGET) -s $(BOARD_KERNEL_PAGESIZE) -p $(KERNEL_OUT)/scripts/dtc/ $(KERNEL_OUT)/arch/arm/boot/
 	@echo -e ${CL_CYN}"Made DT image: $@"${CL_RST}
 
-
-## Overload bootimg generation: Same as the original, + --dt arg
-$(INSTALLED_BOOTIMAGE_TARGET): $(MKBOOTIMG) $(INTERNAL_BOOTIMAGE_FILES) $(INSTALLED_DTIMAGE_TARGET)
-	$(call pretty,"Target boot image: $@")
-	$(hide) $(MKBOOTIMG) $(INTERNAL_BOOTIMAGE_ARGS) $(BOARD_MKBOOTIMG_ARGS) --dt $(INSTALLED_DTIMAGE_TARGET) --output $@
+## Overload android bootimg generation: Same as the original, + --dt arg
+$(INSTALLED_BOOTIMAGE_TARGET_ANDROID): $(MKBOOTIMG) $(INTERNAL_BOOTIMAGE_FILES_ANDROID) $(INSTALLED_DTIMAGE_TARGET)
+	$(call pretty,"Target android boot image: $@")
+	$(hide) $(MKBOOTIMG) $(INTERNAL_BOOTIMAGE_ARGS_ANDROID) $(BOARD_MKBOOTIMG_ARGS) --dt $(INSTALLED_DTIMAGE_TARGET) --output $@
 	$(hide) $(call assert-max-image-size,$@,$(BOARD_BOOTIMAGE_PARTITION_SIZE),raw)
-	@echo -e ${CL_CYN}"Made boot image: $@"${CL_RST}
+	@echo -e ${CL_CYN}"Made android boot image: $@"${CL_RST}
+
+## Overload ubuntu bootimg generation: Same as the original, + --dt arg
+$(INSTALLED_BOOTIMAGE_TARGET): $(MKBOOTIMG) $(INTERNAL_BOOTIMAGE_FILES_) $(INSTALLED_DTIMAGE_TARGET)
+	$(call pretty,"Target boot image for Ubuntu Touch: $@")
+	$(hide) $(MKBOOTIMG) $(INTERNAL_BOOTIMAGE_ARGS) $(INTERNAL_BOOTIMAGE_ARGS_UBUNTU) $(BOARD_MKBOOTIMG_ARGS) --dt $(INSTALLED_DTIMAGE_TARGET) --output $@
+	$(hide) $(call assert-max-image-size,$@,$(BOARD_BOOTIMAGE_PARTITION_SIZE),raw)
+	@echo -e ${CL_CYN}"Made ubuntu boot image: $@"${CL_RST}
 
 ## Overload recoveryimg generation: Same as the original, + --dt arg
 $(INSTALLED_RECOVERYIMAGE_TARGET): $(MKBOOTIMG) $(INSTALLED_DTIMAGE_TARGET) \


### PR DESCRIPTION
alexforsale@elasrofxela:~/temp/unpack/falcon/boot$ unpackbootimg -i boot.img 
Android magic found at: 0
BOARD_KERNEL_CMDLINE 
BOARD_KERNEL_BASE 10000000
BOARD_RAMDISK_OFFSET 01000000
BOARD_SECOND_OFFSET 00f00000
BOARD_TAGS_OFFSET 00000100
BOARD_PAGE_SIZE 2048
BOARD_SECOND_SIZE 0
BOARD_DT_SIZE 1128448

I've tried compiling using your sources, and I can confirm that the INTERNAL_BOOTIMAGE_ARGS doesn't carry the INTERNAL_BOOTIMAGE_ARGS_COMMON which supposedly also carry the BOARD_KERNEL_CMDLINE (you can check by removing the $(hide) from https://github.com/ubuntu-touchCAF/android_build/blob/ubuntu-touch/core/Makefile#L522. )
this commit is from https://github.com/alexforsale/android_device_xiaomi_armani/commit/ab8e864d56f753577a6cb53b2547679403a30afe

please also confirm this by unpacking the boot.img before merging this commits

after this commit the unpackbootimg reports this

alexforsale@elasrofxela:~/temp/unpack/falcon/boot-modified-mk$ unpackbootimg -i boot.img 
Android magic found at: 0
BOARD_KERNEL_CMDLINE androidboot.selinux=permissive console=tty0 apparmor=0 androidboot.hardware=qcom user_debug=31 msm_rtb.filter=0x37 vmalloc=400M utags.blkdev=/dev/block/platform/msm_sdcc.1/by-name/utags androidboot.write_protect=0
BOARD_KERNEL_BASE 00000000
BOARD_RAMDISK_OFFSET 01000000
BOARD_SECOND_OFFSET 00f00000
BOARD_TAGS_OFFSET 00000100
BOARD_PAGE_SIZE 2048
BOARD_SECOND_SIZE 0
BOARD_DT_SIZE 1128448
